### PR TITLE
Fix rendering of LaTeX notations

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,7 +18,6 @@
     MathJax.Hub.Config({
       tex2jax: {
         inlineMath: [ ['$','$'], ["\\(","\\)"] ],
-        displayMath: [ ['$$','$$'] ],
         processEscapes: true,
         processEnvironments: true
       }


### PR DESCRIPTION
LaTeX notations in chapter 4-2, 4-5, etc. were broken.

https://kuis-isle3sw.github.io/IoPLMaterials/textbook/chap04-5.html#%E5%9E%8B%E4%BB%A3%E5%85%A5%E3%81%A8%E3%81%9D%E3%81%AE%E5%AE%9F%E8%A3%85

|before|after|
|-|-|
|[![Image from Gyazo](https://i.gyazo.com/bd355a3812f3f00e6aae91eac27c9adf.png)](https://gyazo.com/bd355a3812f3f00e6aae91eac27c9adf)|[![Image from Gyazo](https://i.gyazo.com/d3ae6bb03ec3198e9bb1100158cbae94.png)](https://gyazo.com/d3ae6bb03ec3198e9bb1100158cbae94)|