### PR TITLE
Add `webrick` to `Gemfile` for latest Ruby env

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "github-pages", group: :jekyll_plugins
+gem "webrick"
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
 # and associated library.


### PR DESCRIPTION
I don't know much about Ruby, but if I use recent Ruby, it complains about `webrick`, so I just add it.