### PR TITLE
ocamlformat: use janestreet profile

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,7 +1,3 @@
 version=0.27.0
-profile=conventional
-break-cases=fit-or-vertical
-break-infix=fit-or-vertical
-break-sequences=true
-doc-comments=before
+profile=janestreet
 parse-docstrings=true

--- a/dune-project
+++ b/dune-project
@@ -25,7 +25,7 @@
   (ocamlformat
    (and
     :with-dev-setup
-    (= 0.26.2)))))
+    (= 0.27.0)))))
 
 (package
  (name miniml-interpreter)
@@ -37,7 +37,7 @@
   (ocamlformat
    (and
     :with-dev-setup
-    (= 0.26.2)))))
+    (= 0.27.0)))))
 
 (package
  (name tutorial)
@@ -48,4 +48,4 @@
   (ocamlformat
    (and
     :with-dev-setup
-    (= 0.26.2)))))
+    (= 0.27.0)))))

--- a/miniml-compiler.opam
+++ b/miniml-compiler.opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml"
   "menhir"
   "ocaml-lsp-server" {with-dev-setup}
-  "ocamlformat" {with-dev-setup & = "0.26.2"}
+  "ocamlformat" {with-dev-setup & = "0.27.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/miniml-interpreter.opam
+++ b/miniml-interpreter.opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml"
   "menhir"
   "ocaml-lsp-server" {with-dev-setup}
-  "ocamlformat" {with-dev-setup & = "0.26.2"}
+  "ocamlformat" {with-dev-setup & = "0.27.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/textbook/camlNyumon.ml
+++ b/textbook/camlNyumon.ml
@@ -18,6 +18,7 @@ let fact2 n =
   match n with
   | 0 -> 1
   | _ -> n * fact (n - 1)
+;;
 
 (* 階乗（末尾再帰 tail recursion）*)
 
@@ -30,6 +31,7 @@ let rec sum l =
   match l with
   | [] -> 0
   | hd :: tl -> hd + sum tl
+;;
 
 (* 整数のリスト l と整数から整数への関数 f を受け取り，f を l の要素そ
    れぞれに適用して得られるリストを返す関数 map を書け *)
@@ -38,18 +40,23 @@ let rec map f l =
   match l with
   | [] -> []
   | hd :: tl -> f hd :: map f tl
+;;
 
 (* 教科書の Exercise 1.0.2 *)
 
 (* 二分木をあらわすデータ型 (variant type) *)
-type bt = Leaf | Node of int * bt * bt
+type bt =
+  | Leaf
+  | Node of int * bt * bt
 
 let rec sumtree t =
   match t with
   | Leaf -> 0
   | Node (n, bt1, bt2) -> n + sumtree bt1 + sumtree bt2
+;;
 
 let rec maptree f t =
   match t with
   | Leaf -> Leaf
   | Node (n, bt1, bt2) -> Node (f n, maptree f bt1, maptree f bt2)
+;;

--- a/textbook/camltutorial/module/main.ml
+++ b/textbook/camltutorial/module/main.ml
@@ -1,5 +1,4 @@
-let rec add n1 n2 =
-  if Nat.iszero n1 then n2 else add (Nat.prev n1) (Nat.succ n2)
+let rec add n1 n2 = if Nat.iszero n1 then n2 else add (Nat.prev n1) (Nat.succ n2)
 
 (* Tests *)
 let () =
@@ -9,3 +8,4 @@ let () =
   assert (repr (add zero zero) = 0);
   assert (repr (prev (succ zero)) = 0);
   assert (repr (add (succ (succ zero)) (succ zero)) = 3)
+;;

--- a/textbook/camltutorial/module/nat.ml
+++ b/textbook/camltutorial/module/nat.ml
@@ -12,7 +12,9 @@
    let repr n = n
 *)
 
-type nat = Zero | Succ of nat
+type nat =
+  | Zero
+  | Succ of nat
 
 let zero = Zero
 let iszero n = n = Zero
@@ -21,13 +23,16 @@ let succ n =
   match n with
   | Zero -> Succ Zero
   | _ -> Succ n
+;;
 
 let prev n =
   match n with
   | Zero -> failwith "Not a natural number."
   | Succ n' -> n'
+;;
 
 let rec repr n =
   match n with
   | Zero -> 0
   | Succ n' -> repr n' + 1
+;;

--- a/textbook/miniml-compiler/bin/main.ml
+++ b/textbook/miniml-compiler/bin/main.ml
@@ -1,9 +1,11 @@
 let debug = ref false
 
 let dprint s =
-  if !debug then (
+  if !debug
+  then (
     print_string (s ());
     flush stdout)
+;;
 
 let display_cfg = ref false
 let optimize = ref false
@@ -12,7 +14,6 @@ let outfile = ref "-"
 let compile prompt ichan cont =
   print_string prompt;
   flush stdout;
-
   (* このmain.ml自体の説明(コンパイラの全体構成) (1章後半) *)
 
   (* Parsing (2章) *)
@@ -32,7 +33,8 @@ let compile prompt ichan cont =
   (* 制御フローグラフを表示 *)
   if !display_cfg && not !optimize then Cfg.display_cfg (Cfg.build vmcode) None;
   let armcode =
-    if !optimize then (
+    if !optimize
+    then (
       (* Low-level opt. (7章 DFA & 最適化) *)
       let regcode = Opt.optimize !display_cfg Arm_spec.nreg vmcode in
       dprint (fun () -> "(* [Reg code] *)\n" ^ Reg.string_of_reg regcode ^ "\n");
@@ -47,6 +49,7 @@ let compile prompt ichan cont =
   if !outfile <> "-" then close_out ochan;
   (* continued... *)
   cont ()
+;;
 
 (* ==== main ==== *)
 
@@ -55,28 +58,30 @@ let usage = "Usage: " ^ Sys.argv.(0) ^ " [-vOG] [-o ofile] [file]"
 
 let aspec =
   Arg.align
-    [
-      ("-o", Arg.Set_string outfile, " Set output file (default: stdout)");
-      ( "-O",
-        Arg.Unit (fun () -> optimize := true),
-        " Perform optimization (default: " ^ string_of_bool !optimize ^ ")" );
-      ( "-G",
-        Arg.Unit (fun () -> display_cfg := true),
-        " Display CFG (default: " ^ string_of_bool !display_cfg ^ ")" );
-      ( "-v",
-        Arg.Unit (fun () -> debug := true),
-        " Print debug info (default: " ^ string_of_bool !debug ^ ")" );
+    [ "-o", Arg.Set_string outfile, " Set output file (default: stdout)"
+    ; ( "-O"
+      , Arg.Unit (fun () -> optimize := true)
+      , " Perform optimization (default: " ^ string_of_bool !optimize ^ ")" )
+    ; ( "-G"
+      , Arg.Unit (fun () -> display_cfg := true)
+      , " Display CFG (default: " ^ string_of_bool !display_cfg ^ ")" )
+    ; ( "-v"
+      , Arg.Unit (fun () -> debug := true)
+      , " Print debug info (default: " ^ string_of_bool !debug ^ ")" )
     ]
+;;
 
 let main () =
   Arg.parse aspec (fun s -> srcfile := s) usage;
-  if !srcfile = "-" then
+  if !srcfile = "-"
+  then (
     let c = stdin in
     let rec k () = compile "# " c k in
-    compile "# " c k
-  else
+    compile "# " c k)
+  else (
     let c = open_in !srcfile in
     let k () = close_in c in
-    compile "" c k
+    compile "" c k)
+;;
 
 let () = main ()

--- a/textbook/miniml-compiler/lib/arm_noreg.ml
+++ b/textbook/miniml-compiler/lib/arm_noreg.ml
@@ -16,29 +16,31 @@ let param_to_reg = function
   | 0 -> A1
   | 1 -> A2
   | i -> err ("invalid parameter: " ^ string_of_int i)
+;;
 
 (* Vm.operandから値を取得し，レジスタrdに格納するような
    stmt listを生成 *)
 let gen_operand rd = function
   | Vm.Param i ->
-      let rs = param_to_reg i in
-      if rd = rs then [] else [ Instr (Mov (rd, R rs)) ]
+    let rs = param_to_reg i in
+    if rd = rs then [] else [ Instr (Mov (rd, R rs)) ]
   | Vm.Local i -> [ Instr (Ldr (rd, local_access i)) ]
   | Vm.Proc lbl -> [ Instr (Ldr (rd, L lbl)) ]
   | Vm.IntV i -> [ Instr (Mov (rd, I i)) ]
+;;
 
 (* ==== 仮想マシンコード --> アセンブリコード ==== *)
 
 (* V.decl -> loc list *)
 let gen_decl (Vm.ProcDecl (name, nlocal, instrs)) =
-  [
-    Dir (D_align 2);
-    Dir (D_global name);
-    Label name;
-    Instr (Mov (A1, I 1));
-    Label (name ^ "_ret");
-    Instr (Bx Lr);
+  [ Dir (D_align 2)
+  ; Dir (D_global name)
+  ; Label name
+  ; Instr (Mov (A1, I 1))
+  ; Label (name ^ "_ret")
+  ; Instr (Bx Lr)
   ]
+;;
 
 (* entry point: Vm.decl list -> stmt list *)
 let codegen vmprog = Dir D_text :: List.concat (List.map gen_decl vmprog)

--- a/textbook/miniml-compiler/lib/arm_reg.ml
+++ b/textbook/miniml-compiler/lib/arm_reg.ml
@@ -9,16 +9,8 @@ let err s = raise (Error s)
 
 (* Reg.reg -> reg *)
 let reg_mappings =
-  [
-    (Reg.reserved_reg, Ip);
-    (0, V1);
-    (1, V2);
-    (2, V3);
-    (3, V4);
-    (4, V5);
-    (5, V6);
-    (6, V7);
-  ]
+  [ Reg.reserved_reg, Ip; 0, V1; 1, V2; 2, V3; 3, V4; 4, V5; 5, V6; 6, V7 ]
+;;
 
 let reg_of r = List.assoc r reg_mappings
 
@@ -30,29 +22,31 @@ let param_to_reg = function
   | 0 -> A1
   | 1 -> A2
   | i -> err ("invalid parameter: " ^ string_of_int i)
+;;
 
 (* Reg.operand から値を取得し，レジスタrdに格納するような
    stmt listを生成 *)
 let gen_operand rd = function
   | Reg.Param i ->
-      let rs = param_to_reg i in
-      if rd = rs then [] else [ Instr (Mov (rd, R rs)) ]
+    let rs = param_to_reg i in
+    if rd = rs then [] else [ Instr (Mov (rd, R rs)) ]
   | Reg.Reg r ->
-      let rs = reg_of r in
-      if rd = rs then [] else [ Instr (Mov (rd, R rs)) ]
+    let rs = reg_of r in
+    if rd = rs then [] else [ Instr (Mov (rd, R rs)) ]
   | Reg.Proc lbl -> [ Instr (Ldr (rd, L lbl)) ]
   | Reg.IntV i -> [ Instr (Mov (rd, I i)) ]
+;;
 
 (* ==== Regマシンコード --> アセンブリコード ==== *)
 
 let gen_decl (Reg.ProcDecl (name, nlocal, instrs)) =
-  [
-    Dir (D_align 2);
-    Dir (D_global name);
-    Label name;
-    Instr (Mov (A1, I 1));
-    Label (name ^ "_ret");
-    Instr (Bx Lr);
+  [ Dir (D_align 2)
+  ; Dir (D_global name)
+  ; Label name
+  ; Instr (Mov (A1, I 1))
+  ; Label (name ^ "_ret")
+  ; Instr (Bx Lr)
   ]
+;;
 
 let codegen regprog = Dir D_text :: List.concat (List.map gen_decl regprog)

--- a/textbook/miniml-compiler/lib/arm_spec.ml
+++ b/textbook/miniml-compiler/lib/arm_spec.ml
@@ -51,8 +51,15 @@ type instr =
   | Sub of reg * reg * addr
 
 (* ==== アセンブラ指示子 ==== *)
-type directive = D_align of int | D_global of string | D_text
-type stmt = Dir of directive | Label of label | Instr of instr
+type directive =
+  | D_align of int
+  | D_global of string
+  | D_text
+
+type stmt =
+  | Dir of directive
+  | Label of label
+  | Instr of instr
 
 let string_of_reg r =
   match r with
@@ -71,6 +78,7 @@ let string_of_reg r =
   | Ip -> "ip"
   | Sp -> "sp"
   | Lr -> "lr"
+;;
 
 (* | Pc -> "pc" *)
 
@@ -79,12 +87,13 @@ let string_of_addr = function
   | R r -> string_of_reg r
   | L lbl -> lbl
   | RI (r, i) -> Printf.sprintf "[%s, #%d]" (string_of_reg r) i
+;;
 
 let string_of_instr instr =
   let emit_instr op rands = op ^ "\t" ^ String.concat ", " rands in
   match instr with
   | Add (r1, r2, a) ->
-      emit_instr "add" [ string_of_reg r1; string_of_reg r2; string_of_addr a ]
+    emit_instr "add" [ string_of_reg r1; string_of_reg r2; string_of_addr a ]
   | B lbl -> emit_instr "b" [ lbl ]
   | Bl lbl -> emit_instr "bl" [ lbl ]
   | Blt lbl -> emit_instr "blt" [ lbl ]
@@ -93,27 +102,30 @@ let string_of_instr instr =
   | Bx r -> emit_instr "bx" [ string_of_reg r ]
   | Cmp (r, a) -> emit_instr "cmp" [ string_of_reg r; string_of_addr a ]
   | Ldr (r, a) ->
-      let str_of_addr =
-        match a with
-        | L l -> "=" ^ l
-        | _ -> string_of_addr a
-      in
-      emit_instr "ldr" [ string_of_reg r; str_of_addr ]
+    let str_of_addr =
+      match a with
+      | L l -> "=" ^ l
+      | _ -> string_of_addr a
+    in
+    emit_instr "ldr" [ string_of_reg r; str_of_addr ]
   | Mov (r, a) -> emit_instr "mov" [ string_of_reg r; string_of_addr a ]
   | Mul (r1, r2, r3) ->
-      emit_instr "mul" [ string_of_reg r1; string_of_reg r2; string_of_reg r3 ]
+    emit_instr "mul" [ string_of_reg r1; string_of_reg r2; string_of_reg r3 ]
   | Str (r, a) -> emit_instr "str" [ string_of_reg r; string_of_addr a ]
   | Sub (r1, r2, a) ->
-      emit_instr "sub" [ string_of_reg r1; string_of_reg r2; string_of_addr a ]
+    emit_instr "sub" [ string_of_reg r1; string_of_reg r2; string_of_addr a ]
+;;
 
 let string_of_directive = function
   | D_align i -> "align " ^ string_of_int i
   | D_global s -> "global " ^ s
   | D_text -> "text"
+;;
 
 let string_of_stmt = function
   | Instr i -> "\t" ^ string_of_instr i
   | Label lbl -> lbl ^ ":"
   | Dir d -> "\t." ^ string_of_directive d
+;;
 
 let string_of prog = String.concat "\n" (List.map string_of_stmt prog)

--- a/textbook/miniml-compiler/lib/cfg.ml
+++ b/textbook/miniml-compiler/lib/cfg.ml
@@ -9,22 +9,25 @@ let err s = raise (Error s)
 (* === CFG (control flow graph) は基本ブロックの配列 === *)
 
 (* === 基本ブロック (basic block) === *)
-type bblock = {
-  mutable labels : Vm.label Set.t;
-  stmts : Vm.instr array;
-  mutable preds : int Set.t;
-  mutable succs : int Set.t;
-}
+type bblock =
+  { mutable labels : Vm.label Set.t
+  ; stmts : Vm.instr array
+  ; mutable preds : int Set.t
+  ; mutable succs : int Set.t
+  }
 
 (* Vm.instrと合わせ，プログラムポイントの指定に用いる
    BEFORE: instrの直前
    AFTER:  instrの直後 *)
-type side = BEFORE | AFTER
+type side =
+  | BEFORE
+  | AFTER
 
 (* ==== 各種表示 ==== *)
 
 let string_of_labels sep lbls =
   if Set.is_empty lbls then "" else String.concat sep (Set.to_list lbls) ^ ":"
+;;
 
 (* 端末上で見やすい表現の文字列(ノード間のエッジは見えない)
    (stmt -> side -> string) option -> bblock array -> string *)
@@ -35,29 +38,33 @@ let string_of_cfg str_of_prop cfg =
     | None -> ""
     | Some f -> "  {" ^ f s p ^ "}\n"
   in
-  String.concat "\n"
+  String.concat
+    "\n"
     (List.map
        (fun bb ->
-         let lbl_str =
-           if Set.is_empty bb.labels then ""
-           else string_of_labels ", " bb.labels ^ "\n"
-         in
-         let body_str =
-           fmt_prop bb.stmts.(0) BEFORE
-           ^ String.concat ""
-               (List.map
-                  (fun stmt -> fmt_stmt stmt ^ fmt_prop stmt AFTER)
-                  (Array.to_list bb.stmts))
-         in
-         lbl_str ^ body_str)
+          let lbl_str =
+            if Set.is_empty bb.labels then "" else string_of_labels ", " bb.labels ^ "\n"
+          in
+          let body_str =
+            fmt_prop bb.stmts.(0) BEFORE
+            ^ String.concat
+                ""
+                (List.map
+                   (fun stmt -> fmt_stmt stmt ^ fmt_prop stmt AFTER)
+                   (Array.to_list bb.stmts))
+          in
+          lbl_str ^ body_str)
        (Array.to_list cfg))
+;;
 
 let rec flatmap_of_string f s =
-  if String.length s = 0 then ""
-  else
+  if String.length s = 0
+  then ""
+  else (
     let c = String.get s 0 in
     let s' = String.sub s 1 (String.length s - 1) in
-    f c ^ flatmap_of_string f s'
+    f c ^ flatmap_of_string f s')
+;;
 
 (* graphviz への入力(文字列)に変換．
    label -> (stmt -> side -> string) option -> bblock array -> string *)
@@ -78,12 +85,12 @@ let dot_of_cfg lbl str_of_prop cfg =
   in
   let bblock_to_node i bb =
     let lbl_str =
-      if Set.is_empty bb.labels then ""
-      else string_of_labels ", " bb.labels ^ "\\l|"
+      if Set.is_empty bb.labels then "" else string_of_labels ", " bb.labels ^ "\\l|"
     in
     let body_str =
       fmt_prop bb.stmts.(0) BEFORE
-      ^ String.concat ""
+      ^ String.concat
+          ""
           (List.map
              (fun stmt -> fmt_stmt stmt ^ fmt_prop stmt AFTER)
              (Array.to_list bb.stmts))
@@ -91,23 +98,24 @@ let dot_of_cfg lbl str_of_prop cfg =
     lbl ^ string_of_int i ^ " [label=\"{" ^ lbl_str ^ body_str ^ "}\"];\n"
   in
   let bblock_to_edge i bb =
-    String.concat "  "
+    String.concat
+      "  "
       (List.map
-         (fun j ->
-           lbl ^ string_of_int i ^ " -> " ^ lbl ^ string_of_int j ^ "\n")
+         (fun j -> lbl ^ string_of_int i ^ " -> " ^ lbl ^ string_of_int j ^ "\n")
          (Set.to_list bb.succs))
   in
   "  "
   ^ String.concat "  " (List.mapi bblock_to_node (Array.to_list cfg))
   ^ "\n  "
   ^ String.concat "  " (List.mapi bblock_to_edge (Array.to_list cfg))
+;;
 
 let dot_of_cfgs str_of_prop cfgs =
   "digraph CFG {\n"
   ^ "  node [shape=record fontname=\"courier\"]\n"
-  ^ String.concat "\n"
-      (List.map (fun (lbl, cfg) -> dot_of_cfg lbl str_of_prop cfg) cfgs)
+  ^ String.concat "\n" (List.map (fun (lbl, cfg) -> dot_of_cfg lbl str_of_prop cfg) cfgs)
   ^ "}\n"
+;;
 
 let emit_graph lbl dot_str =
   let dot_file = "cfg_" ^ lbl ^ ".dot" in
@@ -120,12 +128,12 @@ let emit_graph lbl dot_str =
   (* let _ = Sys.command ("evince " (* for Linux *) ^ pdf_file) in *)
   (* let _ = Sys.command ("cygstart.exe " (* for Cygwin *) ^ pdf_file) in *)
   ()
+;;
 
 (* === アクセス関数 === *)
 
 (* CFGに含まれる全ての文を一つの配列にして返す *)
-let all_stmts cfg =
-  Array.concat (List.map (fun bb -> bb.stmts) (Array.to_list cfg))
+let all_stmts cfg = Array.concat (List.map (fun bb -> bb.stmts) (Array.to_list cfg))
 
 (* CFG中のtgt文の位置(インデックスの組)を返す
    CFG, stmt -> (bblockインデックス, stmtインデックス) *)
@@ -136,18 +144,19 @@ let find_stmt cfg tgt =
       (fun (idx, stmt) -> idx)
       (List.filter
          (fun (idx, stmt) -> stmt == tgt)
-         (List.mapi (fun idx stmt -> (idx, stmt)) (Array.to_list bb.stmts)))
+         (List.mapi (fun idx stmt -> idx, stmt) (Array.to_list bb.stmts)))
   in
   let rs =
     List.concat
       (List.mapi
-         (fun i bb -> List.map (fun j -> (i, j)) (find_in_bb bb))
+         (fun i bb -> List.map (fun j -> i, j) (find_in_bb bb))
          (Array.to_list cfg))
   in
   match rs with
   | [] -> err "no stmt found"
   | [ r ] -> r
   | _ -> err "multiple stmts found"
+;;
 
 (* stmt の predecessors を返す．
    CFG, stmt -> stmtのリスト *)
@@ -155,18 +164,21 @@ let preds cfg stmt =
   let b_idx, s_idx = find_stmt cfg stmt in
   let bb = cfg.(b_idx) in
   let stmts = bb.stmts in
-  if b_idx = 0 && s_idx = 0 then (* BEGIN *)
+  if b_idx = 0 && s_idx = 0
+  then (* BEGIN *)
     []
-  else if s_idx = 0 then
+  else if s_idx = 0
+  then
     (* 基本ブロックの先頭の文 *)
     List.map
       (fun pb_idx ->
-        let pb = cfg.(pb_idx) in
-        let stmts = pb.stmts in
-        stmts.(Array.length stmts - 1))
+         let pb = cfg.(pb_idx) in
+         let stmts = pb.stmts in
+         stmts.(Array.length stmts - 1))
       (Set.to_list bb.preds)
   else (* 基本ブロックの先頭以外の文 *)
     [ stmts.(s_idx - 1) ]
+;;
 
 (* stmt の successors を返す．
    CFG, stmt -> stmt のリスト *)
@@ -174,18 +186,20 @@ let succs cfg stmt =
   let b_idx, s_idx = find_stmt cfg stmt in
   let bb = cfg.(b_idx) in
   let stmts = bb.stmts in
-  if b_idx = Array.length cfg - 1 && s_idx = Array.length stmts - 1 then []
-    (* END *)
-  else if s_idx = Array.length stmts - 1 then
+  if b_idx = Array.length cfg - 1 && s_idx = Array.length stmts - 1
+  then [] (* END *)
+  else if s_idx = Array.length stmts - 1
+  then
     (* 基本ブロックの末尾の文 *)
     List.map
       (fun sb_idx ->
-        let sb = cfg.(sb_idx) in
-        let stmts = sb.stmts in
-        stmts.(0))
+         let sb = cfg.(sb_idx) in
+         let stmts = sb.stmts in
+         stmts.(0))
       (Set.to_list bb.succs)
   else (* 基本ブロックの末尾以外の文 *)
     [ stmts.(s_idx + 1) ]
+;;
 
 (* === CFG構築 === *)
 
@@ -196,27 +210,29 @@ let coalesce_label lbl instrs =
   let lis =
     List.fold_left
       (fun stmts instr ->
-        match stmts with
-        | [] -> (
-            match instr with
-            | Vm.Label l -> [ (Set.singleton l, None) ]
-            | _ -> [ (Set.empty, Some instr) ])
-        | stmt :: stmts' -> (
-            match (instr, stmt) with
+         match stmts with
+         | [] ->
+           (match instr with
+            | Vm.Label l -> [ Set.singleton l, None ]
+            | _ -> [ Set.empty, Some instr ])
+         | stmt :: stmts' ->
+           (match instr, stmt with
             | Vm.Label l, (lbls, None) -> (Set.insert l lbls, None) :: stmts'
             | Vm.Label l, (_, Some _) -> (Set.singleton l, None) :: stmts
             | _, (lbls, None) -> (lbls, Some instr) :: stmts'
             | _, (_, Some _) -> (Set.empty, Some instr) :: stmts))
-      [] instrs
+      []
+      instrs
   in
-  [ (Set.singleton lbl, Vm.BEGIN lbl) ]
+  [ Set.singleton lbl, Vm.BEGIN lbl ]
   @ List.rev
       (List.map
          (function
-           | lbls, Some instr -> (lbls, instr)
+           | lbls, Some instr -> lbls, instr
            | _, None -> err "ill formed stmts")
          lis)
-  @ [ (Set.empty, Vm.END lbl) ]
+  @ [ Set.empty, Vm.END lbl ]
+;;
 
 (* 基本ブロックの先頭にあたるラベル付き文をleaderと呼ぶ．
    leader集合を見つけて返す．
@@ -231,19 +247,20 @@ let find_leaders lstmts =
   let _, r =
     List.fold_left
       (fun (is_leader, leaders) stmt ->
-        let leaders' = if is_leader then Set.insert stmt leaders else leaders in
-        match snd stmt with
-        | Vm.BEGIN _ -> (true, leaders')
-        | Vm.END _ -> (false, Set.insert stmt leaders')
-        | Vm.Move _ | Vm.BinOp _ | Vm.Call _ | Vm.Malloc _ | Vm.Read _ ->
-            (false, leaders')
-        | Vm.BranchIf (_, lbl) -> (true, Set.insert (find_target lbl) leaders')
-        | Vm.Goto lbl -> (true, Set.insert (find_target lbl) leaders')
-        | Vm.Return _ -> (true, leaders')
-        | Vm.Label _ -> err "no such case")
-      (true, Set.empty) lstmts
+         let leaders' = if is_leader then Set.insert stmt leaders else leaders in
+         match snd stmt with
+         | Vm.BEGIN _ -> true, leaders'
+         | Vm.END _ -> false, Set.insert stmt leaders'
+         | Vm.Move _ | Vm.BinOp _ | Vm.Call _ | Vm.Malloc _ | Vm.Read _ -> false, leaders'
+         | Vm.BranchIf (_, lbl) -> true, Set.insert (find_target lbl) leaders'
+         | Vm.Goto lbl -> true, Set.insert (find_target lbl) leaders'
+         | Vm.Return _ -> true, leaders'
+         | Vm.Label _ -> err "no such case")
+      (true, Set.empty)
+      lstmts
   in
   r
+;;
 
 (* 基本ブロックのコンストラクタ
    ラベル付き文のリスト -> エッジ情報が未設定のbblock *)
@@ -251,12 +268,12 @@ let make_bblock lstmts =
   match lstmts with
   | [] -> err "make_bblock: invalid argument."
   | (lbls, i) :: lstmts' ->
-      {
-        labels = lbls;
-        stmts = Array.of_list (List.map snd lstmts);
-        preds = Set.empty;
-        succs = Set.empty;
-      }
+    { labels = lbls
+    ; stmts = Array.of_list (List.map snd lstmts)
+    ; preds = Set.empty
+    ; succs = Set.empty
+    }
+;;
 
 (* leader情報をつかってstmtリストを基本ブロックに分割
    stmt list -> leader集合(stmt Set.t) -> bblock list *)
@@ -266,12 +283,15 @@ let split stmts leaders =
        (fun bb -> make_bblock (List.rev bb))
        (List.fold_left
           (fun bbs stmt ->
-            if Set.member stmt leaders then [ stmt ] :: bbs
-            else
-              match bbs with
-              | bb :: bbs' -> (stmt :: bb) :: bbs'
-              | [] -> err "no such case.")
-          [] stmts))
+             if Set.member stmt leaders
+             then [ stmt ] :: bbs
+             else (
+               match bbs with
+               | bb :: bbs' -> (stmt :: bb) :: bbs'
+               | [] -> err "no such case."))
+          []
+          stmts))
+;;
 
 (* 制御フローに従い，基本ブロック間にエッジを張る
    bbリスト -> used_lbls -> エッジの張られたbb配列(CFG)
@@ -294,7 +314,7 @@ let set_edges bbs used_lbls =
   (* 先頭ラベルにlblを含む基本ブロックを探し，そのインデックスを返す．
      さらに，見つかれば，使用ラベル集合u-lblsにそのラベルを追加 *)
   let labels_to_index_map =
-    List.mapi (fun i lbls -> (lbls, i)) (List.map (fun bb -> bb.labels) bbs)
+    List.mapi (fun i lbls -> lbls, i) (List.map (fun bb -> bb.labels) bbs)
   in
   let find_target_bblock lbl =
     try
@@ -303,37 +323,37 @@ let set_edges bbs used_lbls =
       in
       Queue.add lbl used_lbls;
       idx
-    with Not_found -> err ("target label not found: " ^ lbl)
+    with
+    | Not_found -> err ("target label not found: " ^ lbl)
   in
   (* bblockリスト(とそのインデックス)を先頭から順に処理 *)
   List.iteri
     (fun i bb ->
-      match bb.stmts.(Array.length bb.stmts - 1) with
-      | Vm.BEGIN _ -> add_edge i (i + 1)
-      | Vm.END _ -> ()
-      | Vm.Move _ | Vm.BinOp _ | Vm.Call _ | Vm.Malloc _ | Vm.Read _ ->
-          add_edge i (i + 1)
-      | Vm.Label _ -> err "no such case"
-      | Vm.BranchIf (_, lbl) ->
-          add_edge i (find_target_bblock lbl);
-          add_edge i (i + 1)
-      | Vm.Goto lbl -> add_edge i (find_target_bblock lbl)
-      | Vm.Return _ -> add_edge i (List.length bbs - 1))
+       match bb.stmts.(Array.length bb.stmts - 1) with
+       | Vm.BEGIN _ -> add_edge i (i + 1)
+       | Vm.END _ -> ()
+       | Vm.Move _ | Vm.BinOp _ | Vm.Call _ | Vm.Malloc _ | Vm.Read _ -> add_edge i (i + 1)
+       | Vm.Label _ -> err "no such case"
+       | Vm.BranchIf (_, lbl) ->
+         add_edge i (find_target_bblock lbl);
+         add_edge i (i + 1)
+       | Vm.Goto lbl -> add_edge i (find_target_bblock lbl)
+       | Vm.Return _ -> add_edge i (List.length bbs - 1))
     bbs;
   bbv
+;;
 
 (* 各基本ブロックの先頭ラベル集合から未使用ラベルを取り除く
    bblock配列 -> ラベル集合 -> bblock配列 *)
 let gc_label cfg used_lbls =
   Array.iter
     (fun bb ->
-      bb.labels <-
-        Set.from_list
-          (List.filter
-             (fun lbl -> Set.member lbl used_lbls)
-             (Set.to_list bb.labels)))
+       bb.labels
+       <- Set.from_list
+            (List.filter (fun lbl -> Set.member lbl used_lbls) (Set.to_list bb.labels)))
     cfg;
   cfg
+;;
 
 (* label -> VM.instr list -> CFG (bblock配列) *)
 let vm_to_cfg lbl instrs =
@@ -345,14 +365,16 @@ let vm_to_cfg lbl instrs =
   (* gc_label bbv (Queue.fold (fun s l -> Set.insert l s)
      Set.empty used_labels) *)
   bbv
+;;
 
 (* visualize graph *)
 let display_cfg cfgs string_of_prop =
-  emit_graph "tmp"
-    (dot_of_cfgs string_of_prop (List.map (fun (lbl, cfg) -> (lbl, cfg)) cfgs))
+  emit_graph
+    "tmp"
+    (dot_of_cfgs string_of_prop (List.map (fun (lbl, cfg) -> lbl, cfg) cfgs))
+;;
 
 (* entry point *)
 let build vmcode =
-  List.map
-    (fun (Vm.ProcDecl (lbl, _, body)) -> (lbl, vm_to_cfg lbl body))
-    vmcode
+  List.map (fun (Vm.ProcDecl (lbl, _, body)) -> lbl, vm_to_cfg lbl body) vmcode
+;;

--- a/textbook/miniml-compiler/lib/closure.ml
+++ b/textbook/miniml-compiler/lib/closure.ml
@@ -12,7 +12,9 @@ type binOp = S.binOp
 let fresh_id = N.fresh_id
 
 (* ==== 値 ==== *)
-type value = Var of id | IntV of int
+type value =
+  | Var of id
+  | IntV of int
 
 (* ==== 式 ==== *)
 type cexp =
@@ -41,75 +43,72 @@ let string_of_closure e =
   let pr_of_value = function
     | Var id -> text id
     | IntV i ->
-        let s = text (string_of_int i) in
-        if i < 0 then text "(" <*> s <*> text ")" else s
+      let s = text (string_of_int i) in
+      if i < 0 then text "(" <*> s <*> text ")" else s
   in
   let pr_of_values = function
     | [] -> text "()"
     | v :: vs' ->
-        text "("
-        <*> List.fold_left
-              (fun d v -> d <*> text "," <+> pr_of_value v)
-              (pr_of_value v) vs'
-        <*> text ")"
+      text "("
+      <*> List.fold_left (fun d v -> d <*> text "," <+> pr_of_value v) (pr_of_value v) vs'
+      <*> text ")"
   in
   let pr_of_ids = function
     | [] -> text "()"
     | id :: ids' ->
-        text "("
-        <*> List.fold_left (fun d i -> d <*> text "," <+> text i) (text id) ids'
-        <*> text ")"
+      text "("
+      <*> List.fold_left (fun d i -> d <*> text "," <+> text i) (text id) ids'
+      <*> text ")"
   in
   let rec pr_of_cexp p e =
     let enclose p' e = if p' < p then text "(" <*> e <*> text ")" else e in
     match e with
     | ValExp v -> pr_of_value v
-    | BinOp (op, v1, v2) ->
-        enclose 2 (pr_of_value v1 <+> pr_of_op op <+> pr_of_value v2)
+    | BinOp (op, v1, v2) -> enclose 2 (pr_of_value v1 <+> pr_of_op op <+> pr_of_value v2)
     | AppExp (f, vs) -> enclose 3 (pr_of_value f <+> pr_of_values vs)
     | IfExp (v, e1, e2) ->
-        enclose 1
-          (nest 2
-             (group
-                (text "if 0 <"
-                <+> pr_of_value v
-                <+> text "then"
-                <|> pr_of_exp 1 e1))
-          <|> nest 2 (group (text "else" <|> pr_of_exp 1 e2)))
+      enclose
+        1
+        (nest
+           2
+           (group (text "if 0 <" <+> pr_of_value v <+> text "then" <|> pr_of_exp 1 e1))
+         <|> nest 2 (group (text "else" <|> pr_of_exp 1 e2)))
     | TupleExp vs -> pr_of_values vs
-    | ProjExp (v, i) ->
-        enclose 2 (pr_of_value v <*> text "." <*> text (string_of_int i))
+    | ProjExp (v, i) -> enclose 2 (pr_of_value v <*> text "." <*> text (string_of_int i))
   and pr_of_exp p e =
     let enclose p' e = if p' < p then text "(" <*> e <*> text ")" else e in
     match e with
     | CompExp ce -> pr_of_cexp p ce
     | LetExp (id, ce, e) ->
-        enclose 1
-          (nest 2
-             (group (text "let" <+> text id <+> text "=" <|> pr_of_cexp 1 ce))
-          <+> text "in"
-          <|> pr_of_exp 1 e)
+      enclose
+        1
+        (nest 2 (group (text "let" <+> text id <+> text "=" <|> pr_of_cexp 1 ce))
+         <+> text "in"
+         <|> pr_of_exp 1 e)
     | LetRecExp (id, parms, body, e) ->
-        enclose 1
-          (nest 2
-             (group
-                (text "let"
-                <+> text "rec"
-                <+> text id
-                <+> pr_of_ids parms
-                <+> text "="
-                <|> pr_of_exp 1 body))
-          <+> text "in"
-          <|> pr_of_exp 1 e)
+      enclose
+        1
+        (nest
+           2
+           (group
+              (text "let"
+               <+> text "rec"
+               <+> text id
+               <+> pr_of_ids parms
+               <+> text "="
+               <|> pr_of_exp 1 body))
+         <+> text "in"
+         <|> pr_of_exp 1 e)
     | LoopExp (id, ce, e) ->
-        enclose 1
-          (nest 2
-             (group (text "loop" <+> text id <+> text "=" <|> pr_of_cexp 1 ce))
-          <+> text "in"
-          <|> pr_of_exp 1 e)
+      enclose
+        1
+        (nest 2 (group (text "loop" <+> text id <+> text "=" <|> pr_of_cexp 1 ce))
+         <+> text "in"
+         <|> pr_of_exp 1 e)
     | RecurExp v -> enclose 3 (text "recur" <+> pr_of_value v)
   in
   layout (pretty 40 (pr_of_exp 0 e))
+;;
 
 (* entry point *)
 let convert exp = CompExp (ValExp (IntV 1))

--- a/textbook/miniml-compiler/lib/dfa.ml
+++ b/textbook/miniml-compiler/lib/dfa.ml
@@ -5,33 +5,45 @@ exception Error of string
 
 let err s = raise (Error s)
 
-type direction = FORWARD | BACKWARD
-type prop_ordering = LT | EQ | GT | NO
+type direction =
+  | FORWARD
+  | BACKWARD
+
+type prop_ordering =
+  | LT
+  | EQ
+  | GT
+  | NO
 
 (* プロパティ'a を求める解析器を表すデータ型 *)
-type 'a analysis = {
-  direction : direction;
-  transfer : 'a -> Vm.instr -> 'a;
-  compare : 'a -> 'a -> prop_ordering;
-  lub : 'a -> 'a -> 'a;
-  bottom : 'a;
-  init : 'a;
-  to_str : 'a -> string;
-}
+type 'a analysis =
+  { direction : direction
+  ; transfer : 'a -> Vm.instr -> 'a
+  ; compare : 'a -> 'a -> prop_ordering
+  ; lub : 'a -> 'a -> 'a
+  ; bottom : 'a
+  ; init : 'a
+  ; to_str : 'a -> string
+  }
 
 (* 解析結果．プログラムポイント(instr * BEFORE/AFTER) -> プロパティ *)
-type 'a result = { before : (Vm.instr, 'a) Map.t; after : (Vm.instr, 'a) Map.t }
+type 'a result =
+  { before : (Vm.instr, 'a) Map.t
+  ; after : (Vm.instr, 'a) Map.t
+  }
 
 (* 解析結果から指定のプログラムポイントのプロパティを取得 *)
 let get_property rslt stmt side =
   match
-    Map.get stmt
+    Map.get
+      stmt
       (match side with
-      | Cfg.BEFORE -> rslt.before
-      | Cfg.AFTER -> rslt.after)
+       | Cfg.BEFORE -> rslt.before
+       | Cfg.AFTER -> rslt.after)
   with
   | Some p -> p
   | None -> err ("property not found: " ^ Vm.string_of_instr "" "\t" stmt)
+;;
 
 (* データフロー解析を実行 *)
 let solve anlys cfg =
@@ -48,11 +60,12 @@ let solve anlys cfg =
      wlの各要素は (stmt, プロパティ)．stmtの直前(直後)のプロパティへの
      追加を表す． *)
   let rec fixed_point wl entries exits =
-    if Queue.is_empty wl then
+    if Queue.is_empty wl
+    then (
       match anlys.direction with
       | FORWARD -> { before = entries; after = exits }
-      | BACKWARD -> { before = exits; after = entries }
-    else
+      | BACKWARD -> { before = exits; after = entries })
+    else (
       let stmt, prop = Queue.take wl in
       let old_entry_prop = get_prop entries stmt in
       (* 追加されるプロパティとの least upper bound を計算 *)
@@ -60,24 +73,26 @@ let solve anlys cfg =
       (* 差分の有無で場合分け *)
       match anlys.compare new_entry_prop old_entry_prop with
       | EQ -> fixed_point wl entries exits
-      | GT -> (
-          let old_exit_prop = get_prop exits stmt in
-          let new_exit_prop = anlys.transfer new_entry_prop stmt in
-          (* 差分の有無で場合分け *)
-          match anlys.compare new_exit_prop old_exit_prop with
-          | EQ -> fixed_point wl (Map.assoc stmt new_entry_prop entries) exits
-          | GT ->
-              List.iter (* wlにsuccs (preds)を追加 *)
-                (fun stmt -> Queue.add (stmt, new_exit_prop) wl)
-                ((match anlys.direction with
-                 | FORWARD -> Cfg.succs
-                 | BACKWARD -> Cfg.preds)
-                   cfg stmt);
-              fixed_point wl
-                (Map.assoc stmt new_entry_prop entries)
-                (Map.assoc stmt new_exit_prop exits)
-          | _ -> err "transfer not monotone.")
-      | _ -> err "lub operation not adequate."
+      | GT ->
+        let old_exit_prop = get_prop exits stmt in
+        let new_exit_prop = anlys.transfer new_entry_prop stmt in
+        (* 差分の有無で場合分け *)
+        (match anlys.compare new_exit_prop old_exit_prop with
+         | EQ -> fixed_point wl (Map.assoc stmt new_entry_prop entries) exits
+         | GT ->
+           List.iter (* wlにsuccs (preds)を追加 *)
+             (fun stmt -> Queue.add (stmt, new_exit_prop) wl)
+             ((match anlys.direction with
+               | FORWARD -> Cfg.succs
+               | BACKWARD -> Cfg.preds)
+                cfg
+                stmt);
+           fixed_point
+             wl
+             (Map.assoc stmt new_entry_prop entries)
+             (Map.assoc stmt new_exit_prop exits)
+         | _ -> err "transfer not monotone.")
+      | _ -> err "lub operation not adequate.")
   in
   let stmts = Cfg.all_stmts cfg in
   let stmts' =
@@ -87,10 +102,9 @@ let solve anlys cfg =
   in
   (* entries, exitsの初期値(すべての文のプロパティがbottom) *)
   let init_prop =
-    Array.fold_left
-      (fun ip stmt -> Map.assoc stmt anlys.bottom ip)
-      Map.empty stmts'
+    Array.fold_left (fun ip stmt -> Map.assoc stmt anlys.bottom ip) Map.empty stmts'
   in
   let worklist = Queue.create () in
   Queue.add (stmts'.(0), anlys.init) worklist;
   fixed_point worklist init_prop init_prop
+;;

--- a/textbook/miniml-compiler/lib/environment.ml
+++ b/textbook/miniml-compiler/lib/environment.ml
@@ -4,13 +4,19 @@ exception Not_bound
 
 let empty = []
 let extend x v env = (x, v) :: env
-let lookup x env = try List.assoc x env with Not_found -> raise Not_bound
+
+let lookup x env =
+  try List.assoc x env with
+  | Not_found -> raise Not_bound
+;;
 
 let rec map f = function
   | [] -> []
   | (id, v) :: rest -> (id, f v) :: map f rest
+;;
 
 let rec fold_right f env a =
   match env with
   | [] -> a
   | (_, v) :: rest -> f v (fold_right f rest a)
+;;

--- a/textbook/miniml-compiler/lib/flat.ml
+++ b/textbook/miniml-compiler/lib/flat.ml
@@ -49,82 +49,73 @@ let string_of_flat prog =
     | Var id -> text id
     | Fun id -> text "#'" <*> text id
     | IntV i ->
-        let s = text (string_of_int i) in
-        if i < 0 then text "(" <*> s <*> text ")" else s
+      let s = text (string_of_int i) in
+      if i < 0 then text "(" <*> s <*> text ")" else s
   in
   let pr_of_values = function
     | [] -> text "()"
     | v :: vs' ->
-        text "("
-        <*> List.fold_left
-              (fun d v -> d <*> text "," <+> pr_of_value v)
-              (pr_of_value v) vs'
-        <*> text ")"
+      text "("
+      <*> List.fold_left (fun d v -> d <*> text "," <+> pr_of_value v) (pr_of_value v) vs'
+      <*> text ")"
   in
   let rec pr_of_cexp p e =
     let enclose p' e = if p' < p then text "(" <*> e <*> text ")" else e in
     match e with
     | ValExp v -> pr_of_value v
-    | BinOp (op, v1, v2) ->
-        enclose 2 (pr_of_value v1 <+> pr_of_op op <+> pr_of_value v2)
+    | BinOp (op, v1, v2) -> enclose 2 (pr_of_value v1 <+> pr_of_op op <+> pr_of_value v2)
     | AppExp (f, vs) -> enclose 3 (pr_of_value f <+> pr_of_values vs)
     | IfExp (v, e1, e2) ->
-        enclose 1
-          (nest 2
-             (group
-                (text "if 0 <"
-                <+> pr_of_value v
-                <+> text "then"
-                <|> pr_of_exp 1 e1))
-          <|> nest 2 (group (text "else" <|> pr_of_exp 1 e2)))
+      enclose
+        1
+        (nest
+           2
+           (group (text "if 0 <" <+> pr_of_value v <+> text "then" <|> pr_of_exp 1 e1))
+         <|> nest 2 (group (text "else" <|> pr_of_exp 1 e2)))
     | TupleExp vs -> pr_of_values vs
-    | ProjExp (v, i) ->
-        enclose 2 (pr_of_value v <*> text "." <*> text (string_of_int i))
+    | ProjExp (v, i) -> enclose 2 (pr_of_value v <*> text "." <*> text (string_of_int i))
   and pr_of_exp p e =
     let enclose p' e = if p' < p then text "(" <*> e <*> text ")" else e in
     match e with
     | CompExp ce -> pr_of_cexp p ce
     | LetExp (id, ce, e) ->
-        enclose 1
-          (nest 2
-             (group (text "let" <+> text id <+> text "=" <|> pr_of_cexp 1 ce))
-          <+> text "in"
-          <|> pr_of_exp 1 e)
+      enclose
+        1
+        (nest 2 (group (text "let" <+> text id <+> text "=" <|> pr_of_cexp 1 ce))
+         <+> text "in"
+         <|> pr_of_exp 1 e)
     | LoopExp (id, ce, e) ->
-        enclose 1
-          (nest 2
-             (group (text "loop" <+> text id <+> text "=" <|> pr_of_cexp 1 ce))
-          <+> text "in"
-          <|> pr_of_exp 1 e)
+      enclose
+        1
+        (nest 2 (group (text "loop" <+> text id <+> text "=" <|> pr_of_cexp 1 ce))
+         <+> text "in"
+         <|> pr_of_exp 1 e)
     | RecurExp v -> enclose 3 (text "recur" <+> pr_of_value v)
   in
   let pr_of_decl = function
     | RecDecl (id, params, body) ->
-        let tparms =
-          match params with
-          | [] -> text ""
-          | param :: params' ->
-              List.fold_left
-                (fun t p -> t <*> text "," <+> text p)
-                (text param) params'
-        in
-        group
-          (text "let"
-          <+> text "rec"
-          <+> group
-                (text id
+      let tparms =
+        match params with
+        | [] -> text ""
+        | param :: params' ->
+          List.fold_left (fun t p -> t <*> text "," <+> text p) (text param) params'
+      in
+      group
+        (text "let"
+         <+> text "rec"
+         <+> group
+               (text id
                 <+> text "("
                 <*> tparms
                 <*> text ")"
                 <+> nest 2 (text "=" <|> pr_of_exp 1 body)))
   in
   layout
-    (pretty 30
-       (List.fold_right
-          (fun decl doc -> pr_of_decl decl <|> nil <|> doc)
-          prog nil))
+    (pretty
+       30
+       (List.fold_right (fun decl doc -> pr_of_decl decl <|> nil <|> doc) prog nil))
+;;
 
 (* ==== フラット化：変数参照と関数参照の区別も同時に行う ==== *)
 
-let flatten exp =
-  [ RecDecl ("_toplevel", [ "p0"; "p1" ], CompExp (ValExp (IntV 1))) ]
+let flatten exp = [ RecDecl ("_toplevel", [ "p0"; "p1" ], CompExp (ValExp (IntV 1))) ]

--- a/textbook/miniml-compiler/lib/live.ml
+++ b/textbook/miniml-compiler/lib/live.ml
@@ -8,41 +8,48 @@ let dummy = Local (-1)
 let bottom = Set.empty
 
 let compare left right =
-  if Set.is_empty (Set.diff left right) then
-    if Set.is_empty (Set.diff right left) then EQ else LT
-  else if Set.is_empty (Set.diff right left) then GT
+  if Set.is_empty (Set.diff left right)
+  then if Set.is_empty (Set.diff right left) then EQ else LT
+  else if Set.is_empty (Set.diff right left)
+  then GT
   else NO
+;;
 
 let lub = Set.union
 
 let string_of_vars vs =
-  String.concat ", "
-    (List.sort String.compare
-       (List.map Vm.string_of_operand
+  String.concat
+    ", "
+    (List.sort
+       String.compare
+       (List.map
+          Vm.string_of_operand
           (List.filter (fun v -> v <> dummy) (Set.to_list vs))))
+;;
 
 let filter_vars vs =
   Set.from_list
     (List.filter
        (fun v ->
-         match v with
-         | Param _ | Local _ -> true
-         | Proc _ | IntV _ -> false)
+          match v with
+          | Param _ | Local _ -> true
+          | Proc _ | IntV _ -> false)
        (Set.to_list vs))
+;;
 
 let transfer entry_vars stmt =
   let gen vs =
     lub
       (filter_vars
          (match stmt with
-         | Move (dst, src) -> Set.singleton src
-         | BinOp (dst, op, l, r) -> Set.from_list [ l; r ]
-         | BranchIf (c, l) -> Set.singleton c
-         | Call (dst, tgt, args) -> Set.insert tgt (Set.from_list args)
-         | Return v -> Set.singleton v
-         | Malloc (dst, vs) -> Set.from_list vs
-         | Read (dst, v, i) -> Set.singleton v
-         | _ -> Set.empty))
+          | Move (dst, src) -> Set.singleton src
+          | BinOp (dst, op, l, r) -> Set.from_list [ l; r ]
+          | BranchIf (c, l) -> Set.singleton c
+          | Call (dst, tgt, args) -> Set.insert tgt (Set.from_list args)
+          | Return v -> Set.singleton v
+          | Malloc (dst, vs) -> Set.from_list vs
+          | Read (dst, v, i) -> Set.singleton v
+          | _ -> Set.empty))
       vs
   in
   let kill vs =
@@ -55,15 +62,16 @@ let transfer entry_vars stmt =
     | _ -> vs
   in
   gen (kill entry_vars)
+;;
 
 let make () =
-  {
-    direction = BACKWARD;
-    transfer;
-    compare;
-    lub;
-    bottom;
-    (* 不動点反復を回すためのdirty hack *)
-    init = Set.singleton dummy;
-    to_str = string_of_vars;
+  { direction = BACKWARD
+  ; transfer
+  ; compare
+  ; lub
+  ; bottom
+  ; (* 不動点反復を回すためのdirty hack *)
+    init = Set.singleton dummy
+  ; to_str = string_of_vars
   }
+;;

--- a/textbook/miniml-compiler/lib/misc.ml
+++ b/textbook/miniml-compiler/lib/misc.ml
@@ -4,11 +4,15 @@
 let fresh_id_maker p =
   let counter = Hashtbl.create 4 in
   let body k =
-    let v = try Hashtbl.find counter k with Not_found -> 0 in
+    let v =
+      try Hashtbl.find counter k with
+      | Not_found -> 0
+    in
     Hashtbl.add counter k (v + 1);
     Printf.sprintf "%s%s%d" p k v
   in
   body
+;;
 
 (* リストxs中の述語pを満たす一つ目の要素の位置を返す *)
 let index_of p xs =
@@ -18,3 +22,4 @@ let index_of p xs =
     | _ :: xs' -> i_of (i + 1) xs'
   in
   i_of 0 xs
+;;

--- a/textbook/miniml-compiler/lib/myMap.ml
+++ b/textbook/miniml-compiler/lib/myMap.ml
@@ -5,33 +5,37 @@ let empty = []
 let is_empty = function
   | [] -> true
   | x :: xs -> false
+;;
 
-let singleton k v = [ (k, v) ]
+let singleton k v = [ k, v ]
 let from_list x = x
 let to_list x = x
 
 let rec assoc k v = function
-  | [] -> [ (k, v) ]
-  | (k', v') :: rest ->
-      if k == k' then (k, v) :: rest else (k', v') :: assoc k v rest
+  | [] -> [ k, v ]
+  | (k', v') :: rest -> if k == k' then (k, v) :: rest else (k', v') :: assoc k v rest
+;;
 
 let rec get k = function
   | [] -> None
   | (k', v') :: rest -> if k == k' then Some v' else get k rest
+;;
 
 let merge xs ys = List.fold_left (fun zs (k, v) -> assoc k v zs) ys xs
 
 let rec remove k = function
   | [] -> []
   | (k', v') :: rest -> if k == k' then rest else (k', v') :: remove k rest
+;;
 
 let contains k = List.exists (fun (k', _) -> k == k')
 
 let rec map f = function
   | [] -> []
   | (k, v) :: rest ->
-      let k', v' = f k v in
-      assoc k' v' (map f rest)
+    let k', v' = f k v in
+    assoc k' v' (map f rest)
+;;
 
 let bigmerge ms =
   let rec bm = function
@@ -39,3 +43,4 @@ let bigmerge ms =
     | map1 :: rest -> merge map1 (bm rest)
   in
   bm (MySet.to_list ms)
+;;

--- a/textbook/miniml-compiler/lib/mySet.ml
+++ b/textbook/miniml-compiler/lib/mySet.ml
@@ -5,6 +5,7 @@ let empty = []
 let is_empty = function
   | [] -> true
   | x :: xs -> false
+;;
 
 let singleton x = [ x ]
 let from_list x = x
@@ -13,12 +14,14 @@ let to_list x = x
 let rec insert x = function
   | [] -> [ x ]
   | y :: rest -> if x = y then y :: rest else y :: insert x rest
+;;
 
 let union xs ys = List.fold_left (fun zs x -> insert x zs) ys xs
 
 let rec remove x = function
   | [] -> []
   | y :: rest -> if x = y then rest else y :: remove x rest
+;;
 
 let diff xs ys = List.fold_left (fun zs x -> remove x zs) xs ys
 let member = List.mem
@@ -26,7 +29,9 @@ let member = List.mem
 let rec map f = function
   | [] -> []
   | x :: rest -> insert (f x) (map f rest)
+;;
 
 let rec bigunion = function
   | [] -> []
   | set1 :: rest -> union set1 (bigunion rest)
+;;

--- a/textbook/miniml-compiler/lib/normal.ml
+++ b/textbook/miniml-compiler/lib/normal.ml
@@ -11,7 +11,9 @@ type binOp = S.binOp
 let fresh_id = Misc.fresh_id_maker "_"
 
 (* ==== 値 ==== *)
-type value = Var of id | IntV of int
+type value =
+  | Var of id
+  | IntV of int
 
 (* ==== 式 ==== *)
 type cexp =
@@ -40,60 +42,59 @@ let string_of_norm e =
   let pr_of_value = function
     | Var id -> text id
     | IntV i ->
-        let s = text (string_of_int i) in
-        if i < 0 then text "(" <*> s <*> text ")" else s
+      let s = text (string_of_int i) in
+      if i < 0 then text "(" <*> s <*> text ")" else s
   in
   let rec pr_of_cexp p e =
     let enclose p' e = if p' < p then text "(" <*> e <*> text ")" else e in
     match e with
     | ValExp v -> pr_of_value v
-    | BinOp (op, v1, v2) ->
-        enclose 2 (pr_of_value v1 <+> pr_of_op op <+> pr_of_value v2)
+    | BinOp (op, v1, v2) -> enclose 2 (pr_of_value v1 <+> pr_of_op op <+> pr_of_value v2)
     | AppExp (f, v) -> enclose 3 (pr_of_value f <+> pr_of_value v)
     | IfExp (v, e1, e2) ->
-        enclose 1
-          (nest 2
-             (group
-                (text "if 0 <"
-                <+> pr_of_value v
-                <+> text "then"
-                <|> pr_of_exp 1 e1))
-          <|> nest 2 (group (text "else" <|> pr_of_exp 1 e2)))
+      enclose
+        1
+        (nest
+           2
+           (group (text "if 0 <" <+> pr_of_value v <+> text "then" <|> pr_of_exp 1 e1))
+         <|> nest 2 (group (text "else" <|> pr_of_exp 1 e2)))
     | TupleExp (v1, v2) ->
-        text "(" <*> pr_of_value v1 <*> text "," <+> pr_of_value v2 <*> text ")"
-    | ProjExp (v, i) ->
-        enclose 2 (pr_of_value v <*> text "." <*> text (string_of_int i))
+      text "(" <*> pr_of_value v1 <*> text "," <+> pr_of_value v2 <*> text ")"
+    | ProjExp (v, i) -> enclose 2 (pr_of_value v <*> text "." <*> text (string_of_int i))
   and pr_of_exp p e =
     let enclose p' e = if p' < p then text "(" <*> e <*> text ")" else e in
     match e with
     | CompExp ce -> pr_of_cexp p ce
     | LetExp (id, ce, e) ->
-        enclose 1
-          (nest 2
-             (group (text "let" <+> text id <+> text "=" <|> pr_of_cexp 1 ce))
-          <+> text "in"
-          <|> pr_of_exp 1 e)
+      enclose
+        1
+        (nest 2 (group (text "let" <+> text id <+> text "=" <|> pr_of_cexp 1 ce))
+         <+> text "in"
+         <|> pr_of_exp 1 e)
     | LetRecExp (id, v, body, e) ->
-        enclose 1
-          (nest 2
-             (group
-                (text "let"
-                <+> text "rec"
-                <+> text id
-                <+> text v
-                <+> text "="
-                <|> pr_of_exp 1 body))
-          <+> text "in"
-          <|> pr_of_exp 1 e)
+      enclose
+        1
+        (nest
+           2
+           (group
+              (text "let"
+               <+> text "rec"
+               <+> text id
+               <+> text v
+               <+> text "="
+               <|> pr_of_exp 1 body))
+         <+> text "in"
+         <|> pr_of_exp 1 e)
     | LoopExp (id, ce, e) ->
-        enclose 1
-          (nest 2
-             (group (text "loop" <+> text id <+> text "=" <|> pr_of_cexp 1 ce))
-          <+> text "in"
-          <|> pr_of_exp 1 e)
+      enclose
+        1
+        (nest 2 (group (text "loop" <+> text id <+> text "=" <|> pr_of_cexp 1 ce))
+         <+> text "in"
+         <|> pr_of_exp 1 e)
     | RecurExp v -> enclose 3 (text "recur" <+> pr_of_value v)
   in
   layout (pretty 30 (pr_of_exp 0 e))
+;;
 
 (* ==== 正規形への変換 ==== *)
 

--- a/textbook/miniml-compiler/lib/opt.ml
+++ b/textbook/miniml-compiler/lib/opt.ml
@@ -10,12 +10,10 @@ let err s = raise (Error s)
    (equalityではなく) identityにより比較されることに注意 *)
 let analyze_cfg anlys cfgs =
   let results = List.map (fun (_, cfg) -> Dfa.solve anlys cfg) cfgs in
-  {
-    Dfa.before =
-      Map.bigmerge (Set.from_list (List.map (fun r -> r.Dfa.before) results));
-    Dfa.after =
-      Map.bigmerge (Set.from_list (List.map (fun r -> r.Dfa.after) results));
+  { Dfa.before = Map.bigmerge (Set.from_list (List.map (fun r -> r.Dfa.before) results))
+  ; Dfa.after = Map.bigmerge (Set.from_list (List.map (fun r -> r.Dfa.after) results))
   }
+;;
 
 (* 各種最適化をここに追加 *)
 let opt lv_results vmcode = vmcode
@@ -31,13 +29,15 @@ let optimize is_disp_cfg nreg vmcode =
   (* 生存変数解析を実行 *)
   let lv_results = analyze_cfg lv cfgs in
   (* 解析結果を表示 *)
-  (if is_disp_cfg then
-     let string_of_prop stmt side =
-       lv.Dfa.to_str (Dfa.get_property lv_results stmt side)
-     in
-     Cfg.display_cfg cfgs (Some string_of_prop));
+  if is_disp_cfg
+  then (
+    let string_of_prop stmt side =
+      lv.Dfa.to_str (Dfa.get_property lv_results stmt side)
+    in
+    Cfg.display_cfg cfgs (Some string_of_prop));
   (* その他，各種最適化 *)
   let vmcode' = opt lv_results vmcode in
   (* 生存変数情報を使って仮想機械コードをレジスタ機械コードへ変換 *)
   let regcode = gen_regcode nreg lv_results vmcode' in
   regcode
+;;

--- a/textbook/miniml-compiler/lib/pretty.ml
+++ b/textbook/miniml-compiler/lib/pretty.ml
@@ -23,25 +23,30 @@ let rec flatten = function
   | Nest (_, d) -> flatten d
   | Group d -> flatten d
   | Append (d, d') -> Append (flatten d, flatten d')
+;;
 
 (* layr : (int * doc) list -> doc list *)
 let rec layr = function
   | [] -> [ "" ]
   | (i, Nil) :: ids -> layr ids
-  | (i, Line) :: ids ->
-      List.map (fun l -> "\n" ^ String.make i ' ' ^ l) (layr ids)
+  | (i, Line) :: ids -> List.map (fun l -> "\n" ^ String.make i ' ' ^ l) (layr ids)
   | (i, Text s) :: ids -> List.map (fun l -> s ^ l) (layr ids)
   | (i, Nest (j, d)) :: ids -> layr ((i + j, d) :: ids)
   | (i, Group d) :: ids -> layr ((i, flatten d) :: ids) @ layr ((i, d) :: ids)
   | (i, Append (d, d')) :: ids -> layr ((i, d) :: (i, d') :: ids)
+;;
 
-let layouts d = layr [ (0, d) ]
+let layouts d = layr [ 0, d ]
 
 let rec fits r l =
-  if r < 0 then false
-  else if l = "" then true
-  else if String.get l 0 = '\n' then true
+  if r < 0
+  then false
+  else if l = ""
+  then true
+  else if String.get l 0 = '\n'
+  then true
   else fits (r - 1) (String.sub l 1 (String.length l - 1))
+;;
 
 let better r lx ly = if fits r lx then lx else ly
 
@@ -53,10 +58,11 @@ let pretty w d =
     | (i, Text s) :: ids -> s ^ best (r - String.length s) ids
     | (i, Nest (j, d)) :: ids -> best r ((i + j, d) :: ids)
     | (i, Group d) :: ids ->
-        better r (best r ((i, flatten d) :: ids)) (best r ((i, d) :: ids))
+      better r (best r ((i, flatten d) :: ids)) (best r ((i, d) :: ids))
     | (i, Append (d, d')) :: ids -> best r ((i, d) :: (i, d') :: ids)
   in
-  best w [ (0, d) ]
+  best w [ 0, d ]
+;;
 
 (* layout: layout -> string *)
 let layout s = s

--- a/textbook/miniml-compiler/lib/reg.ml
+++ b/textbook/miniml-compiler/lib/reg.ml
@@ -17,7 +17,11 @@ type dest =
   (* 局所領域の関数フレーム中の相対位置 *)
   | L of offset
 
-type operand = Param of int | Reg of reg | Proc of label | IntV of int
+type operand =
+  | Param of int
+  | Reg of reg
+  | Proc of label
+  | IntV of int
 
 type instr =
   | Move of reg * operand
@@ -41,70 +45,73 @@ let string_of_binop = function
   | Syntax.Plus -> "add"
   | Syntax.Mult -> "mul"
   | Syntax.Lt -> "lt"
+;;
 
 let string_of_dest = function
   | R r -> "r" ^ string_of_int r
   | L oft -> "t" ^ string_of_int oft
+;;
 
 let string_of_operand = function
   | Param i -> "p" ^ string_of_int i
   | Reg r -> "r" ^ string_of_int r
   | Proc l -> l
   | IntV i -> string_of_int i
+;;
 
 let string_of_instr idt tab = function
-  | Move (t, v) ->
-      idt ^ "move" ^ tab ^ "r" ^ string_of_int t ^ ", " ^ string_of_operand v
+  | Move (t, v) -> idt ^ "move" ^ tab ^ "r" ^ string_of_int t ^ ", " ^ string_of_operand v
   | Load (r, oft) ->
-      idt ^ "load" ^ tab ^ "r" ^ string_of_int r ^ ", t" ^ string_of_int oft
+    idt ^ "load" ^ tab ^ "r" ^ string_of_int r ^ ", t" ^ string_of_int oft
   | Store (r, oft) ->
-      idt ^ "store" ^ tab ^ "r" ^ string_of_int r ^ ", t" ^ string_of_int oft
+    idt ^ "store" ^ tab ^ "r" ^ string_of_int r ^ ", t" ^ string_of_int oft
   | BinOp (t, op, v1, v2) ->
-      idt
-      ^ string_of_binop op
-      ^ tab
-      ^ "r"
-      ^ string_of_int t
-      ^ ", "
-      ^ string_of_operand v1
-      ^ ", "
-      ^ string_of_operand v2
+    idt
+    ^ string_of_binop op
+    ^ tab
+    ^ "r"
+    ^ string_of_int t
+    ^ ", "
+    ^ string_of_operand v1
+    ^ ", "
+    ^ string_of_operand v2
   | Label lbl -> lbl ^ ":"
   | BranchIf (v, lbl) -> idt ^ "bif" ^ tab ^ string_of_operand v ^ ", " ^ lbl
   | Goto lbl -> idt ^ "goto" ^ tab ^ lbl
   | Call (dst, tgt, [ a0; a1 ]) ->
-      idt
-      ^ "call"
-      ^ tab
-      ^ string_of_dest dst
-      ^ ", "
-      ^ string_of_operand tgt
-      ^ "("
-      ^ string_of_operand a0
-      ^ ", "
-      ^ string_of_operand a1
-      ^ ")"
+    idt
+    ^ "call"
+    ^ tab
+    ^ string_of_dest dst
+    ^ ", "
+    ^ string_of_operand tgt
+    ^ "("
+    ^ string_of_operand a0
+    ^ ", "
+    ^ string_of_operand a1
+    ^ ")"
   | Call (_, _, args) ->
-      err ("Illegal number of arguments: " ^ string_of_int (List.length args))
+    err ("Illegal number of arguments: " ^ string_of_int (List.length args))
   | Return v -> idt ^ "ret" ^ tab ^ string_of_operand v
   | Malloc (t, vs) ->
-      idt
-      ^ "new"
-      ^ tab
-      ^ string_of_dest t
-      ^ " ["
-      ^ String.concat ", " (List.map string_of_operand vs)
-      ^ "]"
+    idt
+    ^ "new"
+    ^ tab
+    ^ string_of_dest t
+    ^ " ["
+    ^ String.concat ", " (List.map string_of_operand vs)
+    ^ "]"
   | Read (t, v, i) ->
-      idt
-      ^ "read"
-      ^ tab
-      ^ string_of_dest t
-      ^ " #"
-      ^ string_of_int i
-      ^ "("
-      ^ string_of_operand v
-      ^ ")"
+    idt
+    ^ "read"
+    ^ tab
+    ^ string_of_dest t
+    ^ " #"
+    ^ string_of_int i
+    ^ "("
+    ^ string_of_operand v
+    ^ ")"
+;;
 
 let string_of_decl (ProcDecl (lbl, n, instrs)) =
   "proc "
@@ -114,6 +121,7 @@ let string_of_decl (ProcDecl (lbl, n, instrs)) =
   ^ ") =\n"
   ^ String.concat "\n" (List.map (fun i -> string_of_instr "  " "\t" i) instrs)
   ^ "\n"
+;;
 
 let string_of_reg prog = String.concat "\n" (List.map string_of_decl prog)
 
@@ -122,6 +130,7 @@ let string_of_reg prog = String.concat "\n" (List.map string_of_decl prog)
 let trans_decl nreg lives (Vm.ProcDecl (lbl, nlocal, instrs)) =
   let insts' = [ Return (IntV 1) ] in
   ProcDecl (lbl, 0, insts')
+;;
 
 (* entry point *)
 let trans nreg lives = List.map (trans_decl nreg lives)

--- a/textbook/miniml-compiler/lib/syntax.ml
+++ b/textbook/miniml-compiler/lib/syntax.ml
@@ -3,7 +3,11 @@ exception Error of string
 let err s = raise (Error s)
 
 type id = string
-type binOp = Plus | Mult | Lt
+
+type binOp =
+  | Plus
+  | Mult
+  | Lt
 
 type exp =
   | Var of id

--- a/textbook/miniml-compiler/lib/vm.ml
+++ b/textbook/miniml-compiler/lib/vm.ml
@@ -17,13 +17,11 @@ type operand =
 
 type instr =
   | Move of id * operand (* local(ofs) <- op *)
-  | BinOp of
-      id * S.binOp * operand * operand (* local(ofs) <- bop(op_1, op_2) *)
+  | BinOp of id * S.binOp * operand * operand (* local(ofs) <- bop(op_1, op_2) *)
   | Label of label (* l: *)
   | BranchIf of operand * label (* if op then goto l *)
   | Goto of label (* goto l *)
-  | Call of
-      id * operand * operand list (* local(ofs) <- call op_f(op_1, ..., op_n) *)
+  | Call of id * operand * operand list (* local(ofs) <- call op_f(op_1, ..., op_n) *)
   | Return of operand (* return(op) *)
   | Malloc of id * operand list (* new ofs [op_1, ..., op_n] *)
   | Read of id * operand * int (* read ofs #i(op) *)
@@ -39,69 +37,71 @@ let string_of_binop = function
   | S.Plus -> "add"
   | S.Mult -> "mul"
   | S.Lt -> "lt"
+;;
 
 let string_of_operand = function
   | Param i -> "p" ^ string_of_int i
   | Local o ->
-      (* -1 は生存変数解析で使われる特殊な値 *)
-      if o = -1 then "*" else "t" ^ string_of_int o
+    (* -1 は生存変数解析で使われる特殊な値 *)
+    if o = -1 then "*" else "t" ^ string_of_int o
   | Proc l -> l
   | IntV i -> string_of_int i
+;;
 
 let string_of_instr idt tab = function
-  | Move (t, v) ->
-      idt ^ "move" ^ tab ^ "t" ^ string_of_int t ^ ", " ^ string_of_operand v
+  | Move (t, v) -> idt ^ "move" ^ tab ^ "t" ^ string_of_int t ^ ", " ^ string_of_operand v
   | BinOp (t, op, v1, v2) ->
-      idt
-      ^ string_of_binop op
-      ^ tab
-      ^ "t"
-      ^ string_of_int t
-      ^ ", "
-      ^ string_of_operand v1
-      ^ ", "
-      ^ string_of_operand v2
+    idt
+    ^ string_of_binop op
+    ^ tab
+    ^ "t"
+    ^ string_of_int t
+    ^ ", "
+    ^ string_of_operand v1
+    ^ ", "
+    ^ string_of_operand v2
   | Label lbl -> lbl ^ ":"
   | BranchIf (v, lbl) -> idt ^ "bif" ^ tab ^ string_of_operand v ^ ", " ^ lbl
   | Goto lbl -> idt ^ "goto" ^ tab ^ lbl
   | Call (dst, tgt, [ a0; a1 ]) ->
-      idt
-      ^ "call"
-      ^ tab
-      ^ "t"
-      ^ string_of_int dst
-      ^ ", "
-      ^ string_of_operand tgt
-      ^ "("
-      ^ string_of_operand a0
-      ^ ", "
-      ^ string_of_operand a1
-      ^ ")"
+    idt
+    ^ "call"
+    ^ tab
+    ^ "t"
+    ^ string_of_int dst
+    ^ ", "
+    ^ string_of_operand tgt
+    ^ "("
+    ^ string_of_operand a0
+    ^ ", "
+    ^ string_of_operand a1
+    ^ ")"
   | Call (_, _, args) ->
-      err ("Illegal number of arguments: " ^ string_of_int (List.length args))
+    err ("Illegal number of arguments: " ^ string_of_int (List.length args))
   | Return v -> idt ^ "ret" ^ tab ^ string_of_operand v
   | Malloc (t, vs) ->
-      idt
-      ^ "new"
-      ^ tab
-      ^ "t"
-      ^ string_of_int t
-      ^ " ["
-      ^ String.concat ", " (List.map string_of_operand vs)
-      ^ "]"
+    idt
+    ^ "new"
+    ^ tab
+    ^ "t"
+    ^ string_of_int t
+    ^ " ["
+    ^ String.concat ", " (List.map string_of_operand vs)
+    ^ "]"
   | Read (t, v, i) ->
-      idt
-      ^ "read"
-      ^ tab
-      ^ "t"
-      ^ string_of_int t
-      ^ " #"
-      ^ string_of_int i
-      ^ "("
-      ^ string_of_operand v
-      ^ ")"
+    idt
+    ^ "read"
+    ^ tab
+    ^ "t"
+    ^ string_of_int t
+    ^ " #"
+    ^ string_of_int i
+    ^ "("
+    ^ string_of_operand v
+    ^ ")"
   | BEGIN lbl -> idt ^ "<BEGIN: " ^ lbl ^ ">"
   | END lbl -> idt ^ "<END: " ^ lbl ^ ">"
+;;
 
 let string_of_decl (ProcDecl (lbl, n, instrs)) =
   "proc "
@@ -111,6 +111,7 @@ let string_of_decl (ProcDecl (lbl, n, instrs)) =
   ^ ") =\n"
   ^ String.concat "\n" (List.map (fun i -> string_of_instr "  " "\t" i) instrs)
   ^ "\n"
+;;
 
 let string_of_vm prog = String.concat "\n" (List.map string_of_decl prog)
 
@@ -118,6 +119,7 @@ let string_of_vm prog = String.concat "\n" (List.map string_of_decl prog)
 
 let trans_decl (F.RecDecl (proc_name, params, body)) =
   ProcDecl (proc_name, 1, [ Move (0, IntV 1); Return (Local 0) ])
+;;
 
 (* entry point *)
 let trans = List.map trans_decl

--- a/textbook/miniml-interpreter/lib/cui.ml
+++ b/textbook/miniml-interpreter/lib/cui.ml
@@ -13,8 +13,11 @@ let rec read_eval_print env =
   pp_val v;
   print_newline ();
   read_eval_print newenv
+;;
 
 let initial_env =
-  Environment.extend "i" (IntV 1)
-    (Environment.extend "v" (IntV 5)
-       (Environment.extend "x" (IntV 10) Environment.empty))
+  Environment.extend
+    "i"
+    (IntV 1)
+    (Environment.extend "v" (IntV 5) (Environment.extend "x" (IntV 10) Environment.empty))
+;;

--- a/textbook/miniml-interpreter/lib/environment.ml
+++ b/textbook/miniml-interpreter/lib/environment.ml
@@ -4,13 +4,19 @@ exception Not_bound
 
 let empty = []
 let extend x v env = (x, v) :: env
-let lookup x env = try List.assoc x env with Not_found -> raise Not_bound
+
+let lookup x env =
+  try List.assoc x env with
+  | Not_found -> raise Not_bound
+;;
 
 let rec map f = function
   | [] -> []
   | (id, v) :: rest -> (id, f v) :: map f rest
+;;
 
 let rec fold_right f env a =
   match env with
   | [] -> a
   | (_, v) :: rest -> f v (fold_right f rest a)
+;;

--- a/textbook/miniml-interpreter/lib/eval.ml
+++ b/textbook/miniml-interpreter/lib/eval.ml
@@ -1,6 +1,9 @@
 open Syntax
 
-type exval = IntV of int | BoolV of bool
+type exval =
+  | IntV of int
+  | BoolV of bool
+
 and dnval = exval
 
 exception Error of string
@@ -11,36 +14,40 @@ let err s = raise (Error s)
 let string_of_exval = function
   | IntV i -> string_of_int i
   | BoolV b -> string_of_bool b
+;;
 
 let pp_val v = print_string (string_of_exval v)
 
 let apply_prim op arg1 arg2 =
-  match (op, arg1, arg2) with
+  match op, arg1, arg2 with
   | Plus, IntV i1, IntV i2 -> IntV (i1 + i2)
   | Plus, _, _ -> err "Both arguments must be integer: +"
   | Mult, IntV i1, IntV i2 -> IntV (i1 * i2)
   | Mult, _, _ -> err "Both arguments must be integer: *"
   | Lt, IntV i1, IntV i2 -> BoolV (i1 < i2)
   | Lt, _, _ -> err "Both arguments must be integer: <"
+;;
 
 let rec eval_exp env = function
-  | Var x -> (
-      try Environment.lookup x env
-      with Environment.Not_bound -> err ("Variable not bound: " ^ x))
+  | Var x ->
+    (try Environment.lookup x env with
+     | Environment.Not_bound -> err ("Variable not bound: " ^ x))
   | ILit i -> IntV i
   | BLit b -> BoolV b
   | BinOp (op, exp1, exp2) ->
-      let arg1 = eval_exp env exp1 in
-      let arg2 = eval_exp env exp2 in
-      apply_prim op arg1 arg2
-  | IfExp (exp1, exp2, exp3) -> (
-      let test = eval_exp env exp1 in
-      match test with
-      | BoolV true -> eval_exp env exp2
-      | BoolV false -> eval_exp env exp3
-      | _ -> err "Test expression must be boolean: if")
+    let arg1 = eval_exp env exp1 in
+    let arg2 = eval_exp env exp2 in
+    apply_prim op arg1 arg2
+  | IfExp (exp1, exp2, exp3) ->
+    let test = eval_exp env exp1 in
+    (match test with
+     | BoolV true -> eval_exp env exp2
+     | BoolV false -> eval_exp env exp3
+     | _ -> err "Test expression must be boolean: if")
+;;
 
 let eval_decl env = function
   | Exp e ->
-      let v = eval_exp env e in
-      ("-", env, v)
+    let v = eval_exp env e in
+    "-", env, v
+;;

--- a/textbook/miniml-interpreter/lib/mySet.ml
+++ b/textbook/miniml-interpreter/lib/mySet.ml
@@ -8,12 +8,14 @@ let to_list x = x
 let rec insert x = function
   | [] -> [ x ]
   | y :: rest -> if x = y then y :: rest else y :: insert x rest
+;;
 
 let union xs ys = List.fold_left (fun zs x -> insert x zs) ys xs
 
 let rec remove x = function
   | [] -> []
   | y :: rest -> if x = y then rest else y :: remove x rest
+;;
 
 let diff xs ys = List.fold_left (fun zs x -> remove x zs) xs ys
 let member = List.memq
@@ -21,7 +23,9 @@ let member = List.memq
 let rec map f = function
   | [] -> []
   | x :: rest -> insert (f x) (map f rest)
+;;
 
 let rec bigunion = function
   | [] -> []
   | set1 :: rest -> union set1 (bigunion rest)
+;;

--- a/textbook/miniml-interpreter/lib/syntax.ml
+++ b/textbook/miniml-interpreter/lib/syntax.ml
@@ -1,6 +1,10 @@
 (* ML interpreter / type reconstruction *)
 type id = string
-type binOp = Plus | Mult | Lt
+
+type binOp =
+  | Plus
+  | Mult
+  | Lt
 
 type exp =
   | Var of id
@@ -11,4 +15,10 @@ type exp =
 
 type program = Exp of exp
 type tyvar = int
-type ty = TyInt | TyBool | TyVar of tyvar | TyFun of ty * ty | TyList of ty
+
+type ty =
+  | TyInt
+  | TyBool
+  | TyVar of tyvar
+  | TyFun of ty * ty
+  | TyList of ty

--- a/textbook/tutorial/lib/bakusoku.ml
+++ b/textbook/tutorial/lib/bakusoku.ml
@@ -113,7 +113,10 @@ cube 1 + cube 2 + cube 3
 (* レコード *)
 
 (* レコード型の定義 *)
-type point = { x : int; y : int }
+type point =
+  { x : int
+  ; y : int
+  }
 
 let origin = { x = 0; y = 0 };;
 
@@ -135,15 +138,21 @@ let middle (p1, p2) =
   let { x = p1x; y = p1y } = p1 in
   let { x = p2x; y = p2y } = p2 in
   { x = average (p1x, p2x); y = average (p1y, p2y) }
+;;
 
 let middle ({ x = p1x; y = p1y }, { x = p2x; y = p2y }) =
   { x = average (p1x, p2x); y = average (p1y, p2y) }
+;;
 
 let get_x { x; _ } = x
 
 (* ヴァリアント型 *)
 
-type furikake = Shake | Katsuo | Nori;;
+type furikake =
+  | Shake
+  | Katsuo
+  | Nori
+;;
 
 Shake
 
@@ -164,6 +173,7 @@ let isVeggie f =
   match f with
   | Shake -> false
   | Nori -> true
+;;
 
 (* いろいろなパターン *)
 
@@ -179,21 +189,33 @@ let is_prime_less_than_twenty n =
   | 17 -> true
   | 19 -> true
   | _ -> false (* ワイルドカードパターン *)
+;;
 
 let is_prime_less_than_twenty n =
   (*  or パターン *)
   match n with
   | 2 | 3 | 5 | 7 | 11 | 13 | 17 | 19 -> true
   | _ -> false
+;;
 
 (* 引数のついたヴァリアント *)
 
-type miso = Aka | Shiro | Awase
-type gu = Wakame | Tofu | Radish
+type miso =
+  | Aka
+  | Shiro
+  | Awase
+
+type gu =
+  | Wakame
+  | Tofu
+  | Radish
 
 type dish =
   | PorkCutlet (* コンストラクタ *)
-  | Soup of { m : miso; g : gu }
+  | Soup of
+      { m : miso
+      ; g : gu
+      }
   | Rice of furikake
 ;;
 
@@ -214,16 +236,18 @@ let isSolid d =
   | PorkCutlet -> true
   | Soup m_and_g -> false
   | Rice f -> true
+;;
 
 let price_of_dish d =
   match d with
   | PorkCutlet -> 350
   | Soup m_and_g -> 90
-  | Rice f -> (
-      match f with
-      | Shake -> 90
-      | Katsuo -> 90
-      | Nori -> 80)
+  | Rice f ->
+    (match f with
+     | Shake -> 90
+     | Katsuo -> 90
+     | Nori -> 80)
+;;
 
 let price_of_dish d =
   match d with
@@ -232,6 +256,7 @@ let price_of_dish d =
   | Rice Shake -> 90
   | Rice Katsuo -> 90
   | Rice Nori -> 80
+;;
 
 let price_of_dish d =
   match d with
@@ -239,10 +264,16 @@ let price_of_dish d =
   | Soup m_and_g -> 90
   | Rice (Shake | Katsuo) -> 90
   | Rice Nori -> 80
+;;
 
 (* 再帰ヴァリアント *)
 
-type menu = Smile | Add of { d : dish; next : menu }
+type menu =
+  | Smile
+  | Add of
+      { d : dish
+      ; next : menu
+      }
 
 let m1 = Smile
 
@@ -269,15 +300,19 @@ let rec price_of_menu m =
   match m with
   | Smile -> 0
   | Add { d = d1; next = m' } -> price_of_dish d1 + price_of_menu m'
+;;
 
 (* *)
 
-type 'a mylist = Nil | Cons of 'a * 'a mylist
+type 'a mylist =
+  | Nil
+  | Cons of 'a * 'a mylist
 
 let rec sum ml =
   match ml with
   | Nil -> 0
   | Cons (n, tl) -> n + sum tl
+;;
 
 let rec concat ml =
   match ml with
@@ -299,7 +334,10 @@ concat (Cons ("a", Cons ("b", Nil)))
 (* 変数への破壊的代入ができないことを変数が
    immutable であるという． *)
 
-type mutable_point = { mutable x : int; mutable y : int }
+type mutable_point =
+  { mutable x : int
+  ; mutable y : int
+  }
 
 let m_origin = { x = 0; y = 0 }
 let f y = m_origin.x + y;;
@@ -413,8 +451,7 @@ ignore (1 + 1);
 5
 
 let is_positive n =
-  if n > 0 then print_string "n is positive\n"
-  else print_string "n is not positive\n"
+  if n > 0 then print_string "n is positive\n" else print_string "n is not positive\n"
 ;;
 
 is_positive 100
@@ -435,7 +472,8 @@ is_positive' (-100)
 
 (* はまらないように修正するには *)
 let is_positive n =
-  if n > 0 then (
+  if n > 0
+  then (
     print_int n;
     print_string " is positive")
   else (
@@ -447,7 +485,8 @@ let is_positive n =
 (2 + 3) * 10
 
 let is_positive n =
-  if n > 0 then (
+  if n > 0
+  then (
     print_int n;
     print_string " is positive")
   else (
@@ -523,12 +562,15 @@ function
 
 (* カリー化 *)
 
-type gender = Male | Female
+type gender =
+  | Male
+  | Female
 
 let greeting (gen, name) =
   match gen with
   | Male -> "Hello, Mr. " ^ name
   | Female -> "Hello, Ms. " ^ name
+;;
 
 let g1 = greeting (Male, "Poirot")
 let g2 = greeting (Female, "Marple")
@@ -537,6 +579,7 @@ let curried_greeting gen name =
   match gen with
   | Male -> "Hello, Mr. " ^ name
   | Female -> "Hello, Ms. " ^ name
+;;
 
 let greeting_for_men = curried_greeting Male
 let greeting_for_women = curried_greeting Female
@@ -547,6 +590,7 @@ let curried_greeting gen name =
   match gen with
   | Male -> "Hello, Mr. " ^ name
   | Female -> "Hello, Ms. " ^ name
+;;
 
 let g1 = (curried_greeting Male) "Poirot"
 let g2 = curried_greeting Female "Marple";;
@@ -569,8 +613,7 @@ let g2 = curried_greeting Female "Marple";;
 [ 0; 1; 2 ];;
 [ 0; 1; 2; 3; 4 ]
 
-let rec create_list n len = if len = 0 then [] else n :: create_list n (len - 1)
-;;
+let rec create_list n len = if len = 0 then [] else n :: create_list n (len - 1);;
 
 (*
    create_list 5 3
@@ -589,6 +632,7 @@ create_list 1 10000
 
 let rec create_list_tail n len res =
   if len = 0 then res else create_list_tail n (len - 1) (n :: res)
+;;
 
 let create_list n len = create_list_tail n len []
 
@@ -645,7 +689,7 @@ let rec map f l =
 
 map (fun x -> x + 1) [ 1; 2; 3; 4; 5 ];;
 map (fun x -> x && true) [ true; false; true; false ];;
-map (fun x -> fst x) [ (1, true); (3, false); (7, true) ]
+map (fun x -> fst x) [ 1, true; 3, false; 7, true ]
 
 (* パターンマッチと匿名関数を組み合わせた構文 *)
 
@@ -656,4 +700,4 @@ let rec map f = function
 
 map (fun x -> x + 1) [ 1; 2; 3; 4; 5 ];;
 map (fun x -> x && true) [ true; false; true; false ];;
-map (fun x -> fst x) [ (1, true); (3, false); (7, true) ]
+map (fun x -> fst x) [ 1, true; 3, false; 7, true ]

--- a/tutorial.opam
+++ b/tutorial.opam
@@ -10,7 +10,7 @@ depends: [
   "dune" {>= "3.17"}
   "ocaml"
   "ocaml-lsp-server" {with-dev-setup}
-  "ocamlformat" {with-dev-setup & = "0.26.2"}
+  "ocamlformat" {with-dev-setup & = "0.27.0"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
For readability and explicit `;;` to make the error boundary within the error message clear, the JaneStreet style is best.